### PR TITLE
Use scikit-build to build and link extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ add_library(_nvjitlinklib MODULE nvjitlink/_nvjitlinklib.cpp)
 python_extension_module(_nvjitlinklib)
 
 target_link_libraries(_nvjitlinklib CUDA::nvJitLink_static CUDA::nvptxcompiler_static)
-target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall -O0)
+
+if(WIN32)
+  target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall -/Od)
+else()
+  target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall -O0)
+endif()
 
 install(TARGETS _nvjitlinklib LIBRARY DESTINATION nvjitlink)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+
+enable_language(C CXX)
+
+include(fetch_rapids.cmake)
+
+include(rapids-cmake)
+include(rapids-cpm)
+include(rapids-find)
+
+rapids_cpm_init()
+
+rapids_find_package(
+  CUDAToolkit 12.2 REQUIRED
+)
+
+project(nvjitlink)
+
+find_package(PythonExtensions REQUIRED)
+
+add_library(_nvjitlinklib MODULE nvjitlink/_nvjitlinklib.cpp)
+python_extension_module(_nvjitlinklib)
+
+target_link_libraries(_nvjitlinklib CUDA::nvJitLink_static CUDA::nvptxcompiler_static)
+target_compile_options(_nvjitlinklib PRIVATE -Werror -Wall -O0)
+
+install(TARGETS _nvjitlinklib LIBRARY DESTINATION nvjitlink)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(
     name='nvjitlink',
     version='0.0.0',
     description='nvJitLink Python binding',
-    packages=['nvjitlink'],
-    python_requires=">=3.9"
+    packages=['nvjitlink', 'nvjitlink.tests'],
+    package_data={'nvjitlink.tests': ['test_device_functions.*', 'undefined_extern.cubin']},
+    python_requires=">=3.9",
+
 )

--- a/setup.py
+++ b/setup.py
@@ -12,88 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import os.path
-import shutil
-import sys
-from distutils.command.build_ext import build_ext
-from distutils.sysconfig import get_config_var, get_python_inc
-from setuptools import setup, Extension
-
-include_dirs = [os.path.dirname(get_python_inc())]
-library_dirs = [get_config_var("LIBDIR")]
-
-# Find and add CUDA include paths
-CUDA_HOME = os.environ.get("CUDA_HOME", False)
-if not CUDA_HOME:
-    path_to_cuda_gdb = shutil.which("cuda-gdb")
-    if path_to_cuda_gdb is None:
-        raise OSError(
-            "Could not locate CUDA. "
-            "Please set the environment variable "
-            "CUDA_HOME to the path to the CUDA installation "
-            "and try again."
-        )
-    CUDA_HOME = os.path.dirname(os.path.dirname(path_to_cuda_gdb))
-if not os.path.isdir(CUDA_HOME):
-    raise OSError(f"Invalid CUDA_HOME: directory does not exist: {CUDA_HOME}")
-include_dirs.append(os.path.join(CUDA_HOME, "include"))
-library_dirs.append(os.path.join(CUDA_HOME, "lib64"))
-
-default_werror_wall = sys.platform.startswith('linux')
-
-nvjitlink_be_user_options = [
-    ('werror', None, 'Build extensions with -Werror'),
-    ('wall', None, 'Build extensions with -Wall'),
-    ('noopt', None, 'Build extensions without optimization'),
-]
-
-
-class NvJitLinkBuildExt(build_ext):
-
-    user_options = build_ext.user_options + nvjitlink_be_user_options
-    boolean_options = build_ext.boolean_options + ['werror', 'wall', 'noopt']
-
-    def initialize_options(self):
-        super().initialize_options()
-        self.werror = default_werror_wall
-        self.wall = default_werror_wall
-        self.noopt = 0
-
-    def run(self):
-        extra_compile_args = []
-        if self.noopt:
-            if sys.platform == 'win32':
-                extra_compile_args.append('/Od')
-            else:
-                extra_compile_args.append('-O0')
-        if self.werror:
-            extra_compile_args.append('-Werror')
-        if self.wall:
-            extra_compile_args.append('-Wall')
-        for ext in self.extensions:
-            ext.extra_compile_args.extend(extra_compile_args)
-
-        super().run()
-
-
-cmdclass = {}
-cmdclass['build_ext'] = NvJitLinkBuildExt
-
-module = Extension(
-    'nvjitlink._nvjitlinklib',
-    sources=['nvjitlink/_nvjitlinklib.cpp'],
-    include_dirs=include_dirs,
-    libraries=['nvJitLink_static', 'nvptxcompiler_static'],
-    library_dirs=library_dirs,
-    extra_compile_args=['-Wall', '-Werror'],
-)
-
+from skbuild import setup
 setup(
     name='nvjitlink',
+    version='0.0.0',
     description='nvJitLink Python binding',
-    ext_modules=[module],
-    packages=['nvjitlink', 'nvjitlink.tests'],
-    cmdclass=cmdclass,
-    package_data={'nvjitlink.tests': ['test_device_functions.*', 'undefined_extern.cubin']},
+    packages=['nvjitlink'],
+    python_requires=">=3.9"
 )


### PR DESCRIPTION
This PR converts the build process to use scikit-build which uses cmake under the hood to link the final python extension wrapping the `nvJitLink` c++ library.